### PR TITLE
Removes singleton usm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <groupId>com.github.komcrad.snmp</groupId>
   <artifactId>tnm4j</artifactId>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <name>${project.artifactId}</name>
   <description>A simplified SNMP API for Java, inspired by Jürgen Schönwälder's Tnm extension for Tcl.</description>
   <inceptionYear>2012</inceptionYear>

--- a/src/main/java/com/github/komcrad/snmp/provider/snmp4j/UserTargetStrategy.java
+++ b/src/main/java/com/github/komcrad/snmp/provider/snmp4j/UserTargetStrategy.java
@@ -45,12 +45,12 @@ import com.github.komcrad.snmp.SnmpV3Target;
  * @author Carl Harris
  */
 class UserTargetStrategy implements TargetStrategy {
-  private static final OctetString localEngineId = new OctetString(MPv3.createLocalEngineID());
-  private static final USM usm = new USM(SecurityProtocols.getInstance(),
-      localEngineId, 0);
 
   @Override
   public Target newTarget(SnmpTarget target) {
+	OctetString localEngineId = new OctetString(MPv3.createLocalEngineID());
+	USM usm = new USM(SecurityProtocols.getInstance(),
+		localEngineId, 0);
     if (!(target instanceof SnmpV3Target)) return null;
     SnmpV3Target v3Target = (SnmpV3Target) target;
     Assert.notNull(v3Target.getSecurityName(), "securityName is required");


### PR DESCRIPTION
Removes the Singleton usm object and moves it inside the newTarget function. This is to get around issues with having to restart the jvm in order to change a usernames password.